### PR TITLE
Update rocketpyalpha to rocketpy!

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ pyzmq==22.2.1
 qtconsole==5.1.1
 QtPy==1.10.0
 requests==2.26.0
-rocketpyalpha==0.9.7
+rocketpy==0.9.7
 scipy==1.7.1
 Send2Trash==1.8.0
 six==1.16.0


### PR DESCRIPTION
RocketPy is out of alpha and should now be installed by `pip install rocketpy`. The `rocketpyalpha` packaged will be deprecated and removed from PyPI by the end of 2021.

Note that you can still install `rocketpyalpha==0.9.7` by using `rocketpy==0.9.7`.

By the way, your project is awesome! The RocketPy team would love to talk to you about it when you can!